### PR TITLE
Fix theming issues in Lubuntu and Ubuntu Studio

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 calamares-settings-ubuntu (1:22.10.11ubuntu1) UNRELEASED; urgency=medium
 
   * Fixed a syntax error that led to incorrect sidebar coloring
+  * Set Calamares to launch in windowed mode, avoiding a welcome image scaling
+    issue.
 
  -- Aaron Rainbolt <arraybolt3@gmail.com>  Tue, 04 Oct 2022 20:35:00 -0500
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,10 @@
-calamares-settings-ubuntu (1:22.10.11ubuntu1) UNRELEASED; urgency=medium
+calamares-settings-ubuntu (1:22.10.12) kinetic; urgency=medium
 
   * Fixed a syntax error that led to incorrect sidebar coloring (LP: #1991251).
   * Set Calamares to launch in windowed mode, avoiding a welcome image scaling
     issue.
 
- -- Aaron Rainbolt <arraybolt3@gmail.com>  Tue, 04 Oct 2022 20:35:00 -0500
+ -- Aaron Rainbolt <arraybolt3@gmail.com>  Tue, 04 Oct 2022 20:39:43 -0500
 
 calamares-settings-ubuntu (1:22.10.11) kinetic; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 calamares-settings-ubuntu (1:22.10.11ubuntu1) UNRELEASED; urgency=medium
 
-  * Fixed a syntax error that led to incorrect sidebar coloring
+  * Fixed a syntax error that led to incorrect sidebar coloring (LP: #1991251).
   * Set Calamares to launch in windowed mode, avoiding a welcome image scaling
     issue.
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+calamares-settings-ubuntu (1:22.10.11ubuntu1) UNRELEASED; urgency=medium
+
+  * Fixed a syntax error that led to incorrect sidebar coloring
+
+ -- Aaron Rainbolt <arraybolt3@gmail.com>  Tue, 04 Oct 2022 20:35:00 -0500
+
 calamares-settings-ubuntu (1:22.10.11) kinetic; urgency=medium
 
   * Tackled edge case for if libreoffice-help-$LOCALE doesn't exist but

--- a/lubuntu/branding/lubuntu/branding.desc
+++ b/lubuntu/branding/lubuntu/branding.desc
@@ -1,7 +1,7 @@
 ---
 componentName: lubuntu
 
-windowExpanding:    fullscreen
+windowExpanding:    normal
 
 strings:
     productName:         Lubuntu

--- a/lubuntu/branding/lubuntu/branding.desc
+++ b/lubuntu/branding/lubuntu/branding.desc
@@ -24,6 +24,6 @@ slideshow:               "show.qml"
 slideshowAPI:            1
 
 style:
-   sidebarBackground:    "#808080"
-   sidebarText:          "#FFFFFF"
-   sidebarTextSelect:    "#0068C8"
+   SidebarBackground:    "#808080"
+   SidebarText:          "#FFFFFF"
+   SidebarTextSelect:    "#0068C8"

--- a/ubuntustudio/branding/ubuntustudio/branding.desc
+++ b/ubuntustudio/branding/ubuntustudio/branding.desc
@@ -25,6 +25,6 @@ slideshow:               "show.qml"
 slideshowAPI:            1
 
 style:
-   sidebarBackground:    "#2d2d2d"
-   sidebarText:          "#FFFFFF"
-   sidebarTextSelect:    "#4285F4"
+   SidebarBackground:    "#2d2d2d"
+   SidebarText:          "#FFFFFF"
+   SidebarTextSelect:    "#4285F4"


### PR DESCRIPTION
Changes made in this PR:

- The black sidebar is fixed. Some capitalization changes made the sidebar look normal again
- Calamares on Lubuntu launches in windowed mode rather than fullscreen, removing the annoying amount of whitespace around the welcome image. (I couldn't manage to get the welcome image to scale normally, probably a Calamares bug I would guess.)