### PR TITLE
debian/control: Define the flavor packages as swappable packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ If you want to add a new package for your flavor, here's how to do it:
  2. Edit files and rename the branding directory for your flavor. All of the
     configuration files are pretty self-explanatory, but they're documented
     well upstream, so it shouldn't be hard to put your own spin on things.
- 3. Create a new binary package, and *make sure to Conflicts against all other
-    binary packages in this source package*. This needs to be done because all
+ 3. Create a new binary package, and *make sure to Provides+Conflicts against
+    `calamares-settings-ubuntu-flavor`*. This needs to be done because all
     subdirectories are installed in the same location, so this makes sure that
     nobody tries to install any two binary packages at the same time.
 

--- a/debian/control
+++ b/debian/control
@@ -25,7 +25,8 @@ Package: calamares-settings-kubuntu
 Architecture: all
 Depends: calamares-settings-ubuntu-common (>= ${binary:Version}),
          ${misc:Depends}
-Conflicts: calamares-settings-ubuntustudio, calamares-settings-lubuntu
+Conflicts: calamares-settings-ubuntu-flavor
+Provides: calamares-settings-ubuntu-flavor
 Description: Kubuntu Calamares Settings and Branding
  This package contains the Calamares settings and branding for Kubuntu.
  As part of the branding the installer slideshow is contained within.
@@ -37,7 +38,8 @@ Architecture: all
 Depends: calamares-settings-ubuntu-common (>= ${binary:Version}),
          ${misc:Depends}
 Recommends: lubuntu-installer-prompt
-Conflicts: calamares-settings-ubuntustudio, calamares-settings-kubuntu
+Conflicts: calamares-settings-ubuntu-flavor
+Provides: calamares-settings-ubuntu-flavor
 Description: Lubuntu Calamares Settings and Branding
  This package contains the Calamares settings and branding for Lubuntu.
  As part of the branding the installer slideshow is contained within.
@@ -67,7 +69,8 @@ Package: calamares-settings-ubuntustudio
 Architecture: all
 Depends: calamares-settings-ubuntu-common (>= ${binary:Version}),
          ${misc:Depends}
-Conflicts: calamares-settings-lubuntu, calamares-settings-kubuntu
+Conflicts: calamares-settings-ubuntu-flavor
+Provides: calamares-settings-ubuntu-flavor
 Description: Ubuntu Studio Calamares Settings and Branding
  This package contains the Calamares settings and branding for Ubuntu Studio.
  As part of the branding the installer slideshow is contained within.


### PR DESCRIPTION
It is possible to define packages such that one and only one package with a particular virtual name can be installed. Use that instead of forcing people to enumerate conflicts for every possible flavor.